### PR TITLE
Fix fuzzy controller defaults

### DIFF
--- a/custom_ui/fuzzy_graph_ui/fuzzy_graph_controller.py
+++ b/custom_ui/fuzzy_graph_ui/fuzzy_graph_controller.py
@@ -2,21 +2,21 @@ from mining_algorithms.fuzzy_mining import FuzzyMining
 from api.pickle_save import pickle_load
 
 class FuzzyGraphController():
-    def __init__(self, workingDirectory, default_significance = 0.0, default_correlation = 0.5, default_edge_cutoff = 0.4, default_utility_ration = 0.5):
+    def __init__(self, workingDirectory, default_significance = 0.0, default_correlation = 0.5, default_edge_cutoff = 0.4, default_utility_ratio = 0.5):
         super().__init__()
         self.model = None
         self.workingDirectory = workingDirectory
         self.significance = default_significance
         self.edge_cutoff = default_edge_cutoff
-        self.utility_ration = default_utility_ration
+        self.utility_ratio = default_utility_ratio
         self.correlation = default_correlation
 
     def startMining(self, cases):
         self.model = FuzzyMining(cases)
-        self.mine_and_draw(self.significance, self.correlation, self.edge_cutoff, self.utility_ration)
+        self.mine_and_draw(self.significance, self.correlation, self.edge_cutoff, self.utility_ratio)
 
-    def mine_and_draw(self, significance, correlation, edge_cutoff, utility_ration):
-        graph = self.model.create_graph_with_graphviz(float(significance), float(correlation), float(edge_cutoff), float(utility_ration))
+    def mine_and_draw(self, significance, correlation, edge_cutoff, utility_ratio):
+        graph = self.model.create_graph_with_graphviz(float(significance), float(correlation), float(edge_cutoff), float(utility_ratio))
         graph.render(self.workingDirectory, format=('dot'))
 
         return graph

--- a/custom_ui/fuzzy_graph_ui/fuzzy_graph_view.py
+++ b/custom_ui/fuzzy_graph_ui/fuzzy_graph_view.py
@@ -21,8 +21,8 @@ class FuzzyGraphView(QWidget, AlgorithmViewInterface):
         self.default_edge_cutoff = 0.0
         self.edge_cutoff = self.default_edge_cutoff
 
-        self.default_utility_ration = 0.0
-        self.utility_ratio = self.default_utility_ration
+        self.default_utility_ratio = 0.0
+        self.utility_ratio = self.default_utility_ratio
 
         self.max_significance = 100
         self.min_significance = 0
@@ -39,7 +39,13 @@ class FuzzyGraphView(QWidget, AlgorithmViewInterface):
         self.saveFolder = saveFolder
         # directory where graphviz file is stored for display and export
         self.workingDirectory = workingDirectory
-        self.FuzzyGraphController = FuzzyGraphController(workingDirectory, self.significance, self.edge_cutoff,self.utility_ratio)
+        self.FuzzyGraphController = FuzzyGraphController(
+            workingDirectory,
+            self.significance,
+            self.correlation,
+            self.edge_cutoff,
+            self.utility_ratio,
+        )
 
         self.graphviz_graph = None
         self.graph_widget = HTMLWidget(parent)
@@ -244,5 +250,5 @@ class FuzzyGraphView(QWidget, AlgorithmViewInterface):
         #self.default_significance = 0.7
         #self.default_correlation = 0.5
         #self.default_edge_cutoff = 0.5
-        #self.default_utility_ration = 0.5
+        #self.default_utility_ratio = 0.5
         self.zoom_factor = 1.0


### PR DESCRIPTION
## Summary
- correct typo `utility_ration` -> `utility_ratio`
- pass correlation and cutoff parameters correctly when initializing `FuzzyGraphController`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a296fa428832aa1502ff9da0cf460